### PR TITLE
Pin GitHub Actions to SHA

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigests"
   ],
   "labels": ["dependencies"],
   "regexManagers": [

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,11 +6,9 @@
 #################################
 name: Lint Code Base
 
-#
 # Documentation:
 # https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions
 #
-
 #################################################
 # Start the job on all pull requests on develop #
 #################################################
@@ -36,7 +34,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3
         with:
           # Full Git history is needed to get a proper list of changed files
           fetch-depth: 0
@@ -45,7 +43,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter/slim@v4
+        uses: github/super-linter/slim@a320804d310fdeb8d1a46c6c6c1e615d443b10c9 # renovate: tag=v4
         env:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: develop

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,20 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # renovate: tag=v3
 
       # Login against a Docker registry except on PR
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b # renovate: tag=v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a # renovate: tag=v4
         with:
           images: swissgrc/azure-pipelines-terraform
           tags: |
@@ -35,11 +35,11 @@ jobs:
             type=ref,event=pr
             # set unstable tag for develop branch
             type=raw,value=unstable,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
-      
+
       # Build and push Docker image with Buildx (don't push on PR)
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # renovate: tag=v3
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Docker image tags, and thus GitHub Actions tags, are mutable. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.

While we currently only use GitHub Actions from trusted sources, pinning to SHA still makes sense from a zero trust policy point of view and that we don't need to classify into trusted and untrusted actions.