### PR TITLE
Don't scan release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,8 +37,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # Scan Docker image
+      # Scan Docker image (not for release builds since we will have multiple tags)
       - name: Scan Docker image
+        if: github.event_name != 'release'
         uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe # tag=0.5.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
@@ -47,8 +48,8 @@ jobs:
 
       # Publish scan report to GitHub
       - name: Publish scan report to GitHub        
+        if: ${{ github.event_name != 'release' && always() }}
         uses: github/codeql-action/upload-sarif@41a4ada31ba866a7f1196b9602703a89edd69e22 # tag=v2
-        if: ${{ always() }}
         with:
           sarif_file: trivy-results.sarif
 


### PR DESCRIPTION
Skip scanning of release builds, since we build two tags and this won't work with how the pipeline is currently setup.