### PR TITLE
Build on top of Azure CLI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:11.3-slim
+FROM swissgrc/azure-pipelines-azurecli:2.37.0
 
 LABEL org.opencontainers.image.vendor="Swiss GRC AG"
 LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
@@ -7,69 +7,6 @@ LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker
 
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Install Git
-
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION=1:2.30.2-1
-
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends git=${GIT_VERSION} && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  # Smoke test
-  git version
-
-# Install .NET 6
-
-# renovate: datasource=github-tags depName=dotnet/sdk extractVersion=^v(?<version>.*)$
-ENV DOTNET_VERSION=6.0.301
-# renovate: datasource=repology depName=debian_11/ca-certificates versioning=loose
-ENV CACERTIFICATES_VERSION=20210119
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
-ENV CURL_VERSION=7.74.0-1.3+deb11u1
-
-ENV \
-    # Do not show first run text
-    DOTNET_NOLOGO=true \
-    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true \
-    # Disable telemetry
-    DOTNET_CLI_TELEMETRY_OPTOUT=true \
-    # Enable correct mode for dotnet watch (only mode supported in a container)
-    DOTNET_USE_POLLING_FILE_WATCHER=true \
-    # Skip extraction of XML docs - generally not useful within an image/container - helps performance
-    NUGET_XMLDOC_MODE=skip
-
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends ca-certificates=${CACERTIFICATES_VERSION} curl=${CURL_VERSION} && \
-  curl -o /tmp/packages-microsoft-prod.deb https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb && \
-  dpkg -i /tmp/packages-microsoft-prod.deb && \
-  rm -rf /tmp/* && \
-  apt-get update && apt-get install -y --no-install-recommends dotnet-sdk-6.0=${DOTNET_VERSION}-1 && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  # Smoke test
-  dotnet --version
-
-# Install Azure CLI
-
-# renovate: datasource=github-releases depName=Azure/azure-cli extractVersion=^Azure CLI (?<version>.*)$
-ENV AZURECLI_VERSION=2.37.0
-# renovate: datasource=repology depName=debian_11/lsb-release versioning=loose
-ENV LSBRELEASE_VERSION=11.1.0
-# renovate: datasource=repology depName=debian_11/gnupg2 versioning=loose
-ENV GNUPG_VERSION=2.2.27-2+deb11u1
-
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends lsb-release=${LSBRELEASE_VERSION} gnupg=${GNUPG_VERSION} && \
-  curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
-  AZ_REPO=$(lsb_release -cs) && \
-  echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" > /etc/apt/sources.list.d/azure-cli.list && \
-  apt-get update && apt-get install -y --no-install-recommends azure-cli=${AZURECLI_VERSION}-1~bullseye && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  # Smoke test
-  az version
 
 # Install Terraform
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Docker image to run Terraform commands in [Azure Pipelines container jobs].
 
 ## Usage
 
-This image can be used to run Terraform commands in [Azure Pipelines container jobs]. For executing Azure commands Azure CLI is included as well.
+This image can be used to run Terraform commands in [Azure Pipelines container jobs].
+
+The following software is additionally available in the image:
+
+| Software   | Included since |
+|------------|----------------|
+| Azure Cli  | 0.14.6         |
+| Git        | 1.2.3          |
+| .NET       | 1.2.3          |
+| Docker CLI | vNext          |
 
 ### Azure Pipelines Container Job
 
@@ -54,17 +63,17 @@ Note that two secret variables (`Azure.UserName` and `Azure.Password`) are passe
 
 ### Tags
 
-| Tag      | Description                                                                     | Base Image       | Terraform | Git        | Azure CLI | .NET    | Size                                                                                                                               |
-|----------|---------------------------------------------------------------------------------|------------------|-----------|------------|-----------|---------|------------------------------------------------------------------------------------------------------------------------------------|
-| latest   | Latest stable release (from `main` branch)                                      | debian:11.3-slim | 1.2.3     | 1:2.30.2-1 | 2.37.0    | 6.0.301 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/latest?style=flat-square)   |
-| unstable | Latest unstable release (from `develop` branch)                                 | debian:11.3-slim | 1.2.3     | 1:2.30.2-1 | 2.37.0    | 6.0.301 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/unstable?style=flat-square) |
-| 0.14.6   | [Terraform 0.14.6](https://github.com/hashicorp/terraform/releases/tag/v0.14.6) | azure-cli:2.19.1 | 0.14.6    | N/A        | 2.19.1    | N/A     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.14.6?style=flat-square)   |
-| 0.15.0   | [Terraform 0.15.0](https://github.com/hashicorp/terraform/releases/tag/v0.15.0) | azure-cli:2.22.0 | 0.15.0    | N/A        | 2.22.0    | N/A     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.15.0?style=flat-square)   |
-| 0.15.1   | [Terraform 0.15.1](https://github.com/hashicorp/terraform/releases/tag/v0.15.1) | azure-cli:2.22.1 | 0.15.1    | N/A        | 2.22.1    | N/A     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.15.1?style=flat-square)   |
-| 1.0.8    | [Terraform 1.0.8](https://github.com/hashicorp/terraform/releases/tag/v1.0.8)   | azure-cli:2.28.0 | 1.0.8     | N/A        | 2.28.0    | N/A     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.0.8?style=flat-square)    |
-| 1.2.2    | [Terraform 1.2.2](https://github.com/hashicorp/terraform/releases/tag/v1.2.2)   | azure-cli:2.37.0 | 1.2.2     | N/A        | 2.37.0    | N/A     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.2?style=flat-square)    |
-| 1.2.3    | [Terraform 1.2.3](https://github.com/hashicorp/terraform/releases/tag/v1.2.3)   | debian:11.3-slim | 1.2.3     | 1:2.30.2-1 | 2.37.0    | 6.0.301 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.3?style=flat-square)    |
-| 1.2.4    | [Terraform 1.2.4](https://github.com/hashicorp/terraform/releases/tag/v1.2.4)   | debian:11.3-slim | 1.2.4     | 1:2.30.2-1 | 2.37.0    | 6.0.301 | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.4?style=flat-square)    |
+| Tag      | Description                                                                     | Base Image                               | Terraform | Size                                                                                                                               |
+|----------|---------------------------------------------------------------------------------|------------------------------------------|-----------|------------------------------------------------------------------------------------------------------------------------------------|
+| latest   | Latest stable release (from `main` branch)                                      | debian:11.3-slim                         | 1.2.3     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/latest?style=flat-square)   |
+| unstable | Latest unstable release (from `develop` branch)                                 | swissgrc/azure-pipelines-azurecli:2.37.0 | 1.2.3     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/unstable?style=flat-square) |
+| 0.14.6   | [Terraform 0.14.6](https://github.com/hashicorp/terraform/releases/tag/v0.14.6) | azure-cli:2.19.1                         | 0.14.6    | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.14.6?style=flat-square)   |
+| 0.15.0   | [Terraform 0.15.0](https://github.com/hashicorp/terraform/releases/tag/v0.15.0) | azure-cli:2.22.0                         | 0.15.0    | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.15.0?style=flat-square)   |
+| 0.15.1   | [Terraform 0.15.1](https://github.com/hashicorp/terraform/releases/tag/v0.15.1) | azure-cli:2.22.1                         | 0.15.1    | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/0.15.1?style=flat-square)   |
+| 1.0.8    | [Terraform 1.0.8](https://github.com/hashicorp/terraform/releases/tag/v1.0.8)   | azure-cli:2.28.0                         | 1.0.8     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.0.8?style=flat-square)    |
+| 1.2.2    | [Terraform 1.2.2](https://github.com/hashicorp/terraform/releases/tag/v1.2.2)   | azure-cli:2.37.0                         | 1.2.2     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.2?style=flat-square)    |
+| 1.2.3    | [Terraform 1.2.3](https://github.com/hashicorp/terraform/releases/tag/v1.2.3)   | debian:11.3-slim                         | 1.2.3     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.3?style=flat-square)    |
+| 1.2.4    | [Terraform 1.2.4](https://github.com/hashicorp/terraform/releases/tag/v1.2.4)   | debian:11.3-slim                         | 1.2.4     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.2.4?style=flat-square)    |
 
 ### Configuration
 
@@ -73,13 +82,6 @@ These environment variables are supported:
 | Environment variable   | Default value        | Description                                                      |
 |------------------------|----------------------|------------------------------------------------------------------|
 | TERRAFORM_VERSION      | `1.2.4`              | Version of Terraform installed in the image.                     |
-| GIT_VERSION            | `1:2.30.2-1`         | Version of Git installed in the image.                           |
-| DOTNET_VERSION         | `6.0.301`            | Version of .NET installed in the image.                          |
-| AZURECLI_VERSION       | `2.37.0`             | Version of Azure CLI installed in the image.                     |
-| CACERTIFICATES_VERSION | `20210119`           | Version of `ca-certificates` package used to install components. |
-| CURL_VERSION           | `7.74.0-1.3+deb11u1` | Version of `curl` package used to install components.            |
-| LSBRELEASE_VERSION     | `11.1.0`             | Version of `lsb-release` package used to install components.     |
-| GNUPG_VERSION          | `2.2.27-2+deb11u1`   | Version of `gnupg` package used to install components.           |
 | UNZIP_VERSION          | `6.0-26`             | Version of `unzip` package used to install components.           |
 
 [Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Build on top of swissgrc/azure-pipelines-azurecli image which already contains .NET, Git and Azure CLI.

Brings additionally Docker CLI into the image.