### PR TITLE
Disable Repology updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Git
 
-# renovate: datasource=repology depName=debian_11/git versioning=loose
+#Disabled renovate: datasource=repology depName=debian_11/git versioning=loose
 ENV GIT_VERSION=1:2.30.2-1
 
 RUN apt-get update -y && \
@@ -24,7 +24,7 @@ RUN apt-get update -y && \
 
 # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.*)$
 ENV TERRAFORM_VERSION=1.3.1
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
+#Disabled renovate: datasource=repology depName=debian_11/unzip versioning=loose
 ENV UNZIP_VERSION=6.0-26+deb11u1
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Disable Repology updates until https://github.com/renovatebot/renovate/issues/18144 has been fixed to allow updates from other sources to be processed.