### PR TITLE
Don't ship build dependencies in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,12 @@
-FROM swissgrc/azure-pipelines-azurecli:2.44.1
+# Base image containing dependencies used in builder and final image
+FROM swissgrc/azure-pipelines-azurecli:2.44.1 AS base
 
-LABEL org.opencontainers.image.vendor="Swiss GRC AG"
-LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
-LABEL org.opencontainers.image.title="azure-pipelines-terraform"
-LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-terraform"
+
+# Builder image
+FROM base AS build
 
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Install Git
-
-# renovate: datasource=repology depName=debian_11/git versioning=loose
-ENV GIT_VERSION=1:2.30.2-1
-
-RUN apt-get update -y && \
-  apt-get install -y --no-install-recommends git=${GIT_VERSION} && \
-  apt-get clean && \
-  rm -rf /var/lib/apt/lists/* && \
-  # Smoke test
-  git version
 
 # Install Terraform
 
@@ -30,9 +18,41 @@ ENV UNZIP_VERSION=6.0-26+deb11u1
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends unzip=${UNZIP_VERSION} && \
   curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-  unzip /tmp/terraform.zip -d /usr/bin && \
-  rm -rf /tmp/* && \
+  unzip /tmp/terraform.zip -d /tmp && \
+  rm /tmp/terraform.zip
+
+
+# Final image
+FROM base AS final
+
+LABEL org.opencontainers.image.vendor="Swiss GRC AG"
+LABEL org.opencontainers.image.authors="Swiss GRC AG <opensource@swissgrc.com>"
+LABEL org.opencontainers.image.title="azure-pipelines-terraform"
+LABEL org.opencontainers.image.documentation="https://github.com/swissgrc/docker-azure-pipelines-terraform"
+
+# Make sure to fail due to an error at any stage in shell pipes
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+WORKDIR /
+COPY --from=build /tmp/ /tmp
+
+# Install Git
+
+# renovate: datasource=repology depName=debian_11/git versioning=loose
+ENV GIT_VERSION=1:2.30.2-1
+
+RUN apt-get update -y && \
+  # Install Git
+  apt-get install -y --no-install-recommends git=${GIT_VERSION} && \
+  # Clean up
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
+  # Smoke test
+  git version
+
+# Install Terraform
+
+RUN cp /tmp/terraform /usr/bin/terraform && \
+  rm -rf /tmp/* && \
   # Smoke test
   terraform version

--- a/README.md
+++ b/README.md
@@ -89,14 +89,4 @@ Note that two secret variables (`Azure.UserName` and `Azure.Password`) are passe
 | 1.3.6    | [Terraform 1.3.6](https://github.com/hashicorp/terraform/releases/tag/v1.3.6)   | swissgrc/azure-pipelines-azurecli:2.42.0   | 1.3.6     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.3.6?style=flat-square)    |
 | 1.3.7    | [Terraform 1.3.7](https://github.com/hashicorp/terraform/releases/tag/v1.3.7)   | swissgrc/azure-pipelines-azurecli:2.43.0   | 1.3.7     | ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/swissgrc/azure-pipelines-terraform/1.3.7?style=flat-square)    |
 
-### Configuration
-
-These environment variables are supported:
-
-| Environment variable   | Default value        | Description                                                      |
-|------------------------|----------------------|------------------------------------------------------------------|
-| TERRAFORM_VERSION      | `1.3.8`              | Version of Terraform installed in the image.                     |
-| GIT_VERSION            | `1:2.30.2-1`         | Version of Git installed in the image.                           |
-| UNZIP_VERSION          | `6.0-26+deb11u1`     | Version of `unzip` package used to install components.           |
-
 [Azure Pipelines container jobs]: https://docs.microsoft.com/en-us/azure/devops/pipelines/process/container-phases


### PR DESCRIPTION
Remove dependencies only required for building the image from final image

Fixes #166 