### PR TITLE
Use Deb versioning for Apt packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install Terraform
 
-# renovate: datasource=repology depName=debian_11/curl versioning=loose
+# renovate: datasource=repology depName=debian_11/curl versioning=deb
 ENV CURL_VERSION=7.74.0-1.3+deb11u10
 # renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.*)$
 ENV TERRAFORM_VERSION=1.6.1
-# renovate: datasource=repology depName=debian_11/unzip versioning=loose
+# renovate: datasource=repology depName=debian_11/unzip versioning=deb
 ENV UNZIP_VERSION=6.0-26+deb11u1
 
 RUN apt-get update -y && \


### PR DESCRIPTION
Switch to Deb versioning for Apt packages to support alphanumerical values in version strings.

This avoid having for example `7.74.0-1.3+deb11u9` be seen as a higher version than `7.74.0-1.3+deb11u10` like in #208.