### PR TITLE
Use ADD instead of Curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,21 +8,21 @@ FROM base AS build
 # Make sure to fail due to an error at any stage in shell pipes
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install Terraform
-
-# renovate: datasource=repology depName=debian_12/curl versioning=deb
-ENV CURL_VERSION=7.88.1-10+deb12u6
-# renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.*)$
-ENV TERRAFORM_VERSION=1.9.4
 # renovate: datasource=repology depName=debian_12/unzip versioning=deb
 ENV UNZIP_VERSION=6.0
 
+# Install necessary dependencies
 RUN apt-get update -y && \
-  # Install necessary dependencies
-  apt-get install -y --no-install-recommends curl=${CURL_VERSION} unzip=${UNZIP_VERSION}-28 && \
-  # Download Terraform
-  curl -o /tmp/terraform.zip https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-  unzip /tmp/terraform.zip -d /tmp && \
+  apt-get install -y --no-install-recommends unzip=${UNZIP_VERSION}-28
+
+# Install Terraform
+
+# renovate: datasource=github-releases depName=hashicorp/terraform extractVersion=^v(?<version>.*)$
+ENV TERRAFORM_VERSION=1.9.4
+
+# Download Terraform
+ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip /tmp/terraform.zip
+RUN unzip /tmp/terraform.zip -d /tmp && \
   rm /tmp/terraform.zip
 
 # Install tflint
@@ -30,8 +30,8 @@ RUN apt-get update -y && \
 # renovate: datasource=github-releases depName=terraform-linters/tflint extractVersion=^v(?<version>.*)$
 ENV TFLINT_VERSION=0.53.0
 
-RUN curl -Lo /tmp/tflint.zip https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip && \
-  unzip /tmp/tflint.zip -d /tmp && \
+ADD https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_linux_amd64.zip /tmp/tflint.zip
+RUN unzip /tmp/tflint.zip -d /tmp && \
   rm /tmp/tflint.zip
 
 


### PR DESCRIPTION
Use ADD instead of Curl to download Terraform.

Fixes https://rules.sonarsource.com/docker/RSPEC-7026/